### PR TITLE
Rename to "scale to"

### DIFF
--- a/Scale all in place.sketchplugin
+++ b/Scale all in place.sketchplugin
@@ -10,7 +10,7 @@ var validSelectionTypes = [NSArray arrayWithObjects:[MSShapeGroup class], [MSLay
 var hasValidSelection = hasValidSelection(selection, validSelectionTypes)
 
 if (hasValidSelectionCount && hasValidSelection) {
-  var scalePercentage = [doc askForUserInput:"Scale by (percentage):" initialValue:"0"]
+  var scalePercentage = [doc askForUserInput:"Scale to (percentage):" initialValue:"100"]
 
   if (scalePercentage > 0) {
     for (var i = 0; i < [selection count]; i++) {


### PR DESCRIPTION
The first time I used the plugin, I entered "5" because I expected it to scale everything up by 5% as stated in the dialog box. But because it scales to a percentage, you might want to set 100 as default, so it is clear that I should have entered 105 ;) 
